### PR TITLE
resample: bugfix for auto_lat_lon_step_size() via merged src/lut_meta…

### DIFF
--- a/mintpy/objects/resample.py
+++ b/mintpy/objects/resample.py
@@ -339,9 +339,14 @@ class resample:
             # parameter 1 - lalo_step (output grid)
             if self.lalo_step is None:
                 try:
+                    # ensure the same pixel area before / after geocoding
+                    merged_meta = {**self.lut_meta, **self.src_meta}
                     lat_c = (src_lat0 + src_lat1) / 2.
-                    lat_step, lon_step = ut.auto_lat_lon_step_size(self.src_meta, lat_c)
-                except AttributeError:
+                    lat_step, lon_step = ut.auto_lat_lon_step_size(merged_meta, lat_c)
+
+                except KeyError:
+                    # ensure the same matrix shape before / after geocoding
+                    # if not enough metadata found for the above
                     lat_step = (src_lat1 - src_lat0) / (lut_lat.shape[0] - 1)
                     lon_step = (src_lon1 - src_lon0) / (lut_lat.shape[1] - 1)
                 self.lalo_step = (abs(lat_step) * -1., abs(lon_step))


### PR DESCRIPTION
… dict (#737)

+ merge `lut_meta` and `src_meta` and pass to `utils0.auto_lat_lon_step_size()` for a better chance of having enough metadata to calculate the pixel area constrained new lat/lon step.

+ fix the mis-functioned `try/except` fallback logic bug by using `except KeyError:` instead of `except AttributeError:`.

**Description of proposed changes**

<!-- Please describe changes proposed and **why** you made them. If unsure, open an issue first so we can discuss.-->

**Reminders**

- [ ] Fix #xxxx
- [ ] Pass Codacy code review (green)
- [ ] Pass Circle CI test (green)
- [ ] Make sure that your code follows our style. Use the other functions/files as a basis.
- [ ] If modifying functionality, describe changes to function behavior and arguments in a comment below the function declaration.
- [ ] If adding new functionality, add a detailed description to the documentation and/or an example.
